### PR TITLE
Chore: remove virtual environment activation from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
 dependencies: ## Install project dependencies needed to run the application
 	echo "0.1.0-ci" > VERSION # create VERSION file for avoinding the CI to break
-	python3 -m venv env
-	. env/bin/activate
 	pip3 install -U pip wheel
 	pip3 install -e .[dev]
 
 .PHONY: lint
 lint: ## Run flake8 linter. It will checks syntax errors or undefined names
-	. env/bin/activate
 	flake8 $(git ls-files | grep 'ˆscripts\|\.py$') --count --select=E9,F63,F7,F82 --show-source --statistics --exclude env/
 
 .PHONY: version
@@ -16,7 +13,6 @@ version: ## Create/update VERSION file
 
 .PHONY: autopep
 autopep: ## Run autopep8
-	. env/bin/activate
 	autopep8 --in-place $(git ls-files | grep 'ˆscripts\|\.py$')
 
 .PHONY: clean
@@ -43,7 +39,6 @@ clean-build: ## Clean build folders
 
 .PHONY: run
 run: version ## Start uvicorn app on port 8080
-	. env/bin/activate
 	uvicorn \
 		--host 127.0.0.1 \
 		--port 8080 \
@@ -51,7 +46,6 @@ run: version ## Start uvicorn app on port 8080
 
 .PHONY: test
 test: ## Run tests against the application
-	. env/bin/activate
 	pytest -v
 
 # Display target comments in 'make help'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 
 ## Setup parameters
 
-1. Setup env
+1. Setup dependencies
+  You can use whenever dependency manager you want to. Just run the command below (and the ones following) on behalf of the manager you prefer.
+
   ```bash
   make dependencies
   ```
@@ -69,15 +71,15 @@ Outputs:
 
 ## Release
 
-Once the pypicloud credentials are set on the repository secrets, pushing a tag will trigger a workflow for pushing the package to pypicloud and releasing on the repository as well. Example:
+There is a GitHub action to publish the package to the pypicloud. Since it is triggered manually, it is prefered you tag the code first. So, at the command line:
 
 ```bash
-git tag -a <version> -m "some message" # e.g. git tag -a 1.0.0 -m "Release"
+git tag -a <version> -m "<message>" # e.g. git tag -a 1.0.0 -m "Message"
 
 git push origin <version> # e.g. git push origin 1.0.0
 ```
 
-NOTE: the workflow won't be triggered if the commit message preceding the tag release contains `release-skip` statement. e.g. `git commit -m "some description here - release-skip"`
+* NOTE: For development releases, add `rc*` (release candidate) to the end of the tag, e.g. `git tag -a 1.0.0rc1`
 
 ## Future work
 


### PR DESCRIPTION
PR to attend @zsinx6 idea: now the developer can use whatever package manager like poetry, pipenv, virtualenv, etc.

This is needed since the organization has many people working with different ways of setting up the projects.