### PR TITLE
Armada 536 add email notification to jobbergate

### DIFF
--- a/cluster_agent/jobbergate/api.py
+++ b/cluster_agent/jobbergate/api.py
@@ -65,17 +65,17 @@ async def mark_as_submitted(job_submission_id: int, slurm_job_id: int):
         response.raise_for_status()
 
 
-async def notify_submission_aborted(
+async def notify_submission_rejected(
     params: DoExceptParams, job_submission_id: int
 ) -> None:
     """
-    Notify Jobbergate that a job submission has been aborted.
+    Notify Jobbergate that a job submission has been rejected.
     """
     log_error(params)
-    logger.debug("Informing Jobbergate that the job submission was aborted")
+    logger.debug("Informing Jobbergate that the job submission was rejected")
     await update_status(
         job_submission_id,
-        JobSubmissionStatus.ABORTED,
+        JobSubmissionStatus.REJECTED,
         reported_message=params.final_message,
     )
 

--- a/cluster_agent/jobbergate/constants.py
+++ b/cluster_agent/jobbergate/constants.py
@@ -12,7 +12,7 @@ class JobSubmissionStatus(str, Enum):
     SUBMITTED = "SUBMITTED"
     COMPLETED = "COMPLETED"
     FAILED = "FAILED"
-    ABORTED = "ABORTED"
+    REJECTED = "REJECTED"
 
 
 status_map: DefaultDict[str, JobSubmissionStatus] = defaultdict(

--- a/cluster_agent/jobbergate/submit.py
+++ b/cluster_agent/jobbergate/submit.py
@@ -10,7 +10,7 @@ from cluster_agent.identity.slurmrestd import inject_token
 from cluster_agent.jobbergate.api import (
     fetch_pending_submissions,
     mark_as_submitted,
-    notify_submission_aborted,
+    notify_submission_rejected,
 )
 
 from cluster_agent.jobbergate.schemas import (
@@ -145,11 +145,11 @@ async def submit_pending_jobs():
                 err,
             )
             with JobbergateApiError.handle_errors(
-                f"Could not update status='ABORTED' for {pending_job_submission.id=} via the API",
+                f"Could not update status='REJECTED' for {pending_job_submission.id=} via the API",
                 do_except=log_error,
                 re_raise=False,
             ):
-                await notify_submission_aborted(
+                await notify_submission_rejected(
                     DoExceptParams(
                         JobSubmissionError,
                         final_message=final_message,

--- a/tests/jobbergate/test_api.py
+++ b/tests/jobbergate/test_api.py
@@ -17,7 +17,7 @@ from cluster_agent.jobbergate.api import (
     fetch_pending_submissions,
     fetch_active_submissions,
     mark_as_submitted,
-    notify_submission_aborted,
+    notify_submission_rejected,
     update_status,
 )
 
@@ -334,10 +334,10 @@ async def test_update_status__raises_JobbergateApiError_if_the_response_is_not_2
 
 
 @pytest.mark.asyncio
-async def test_notify_submission_aborted():
+async def test_notify_submission_rejected():
     """
-    Test that ``notify_submission_aborted`` can send a message to Jobbergate
-    and set the job status to ABORTED.
+    Test that ``notify_submission_rejected`` can send a message to Jobbergate
+    and set the job status to REJECTED.
     """
     job_submission_id = 1
     reported_message = (
@@ -361,12 +361,12 @@ async def test_notify_submission_aborted():
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        await notify_submission_aborted(params, job_submission_id)
+        await notify_submission_rejected(params, job_submission_id)
 
         assert update_route.call_count == 1
         assert update_route.calls.last.request.content == json.dumps(
             dict(
-                new_status=JobSubmissionStatus.ABORTED,
+                new_status=JobSubmissionStatus.REJECTED,
                 reported_message=reported_message,
             ),
         ).encode("utf-8")

--- a/tests/jobbergate/test_submit.py
+++ b/tests/jobbergate/test_submit.py
@@ -389,4 +389,4 @@ async def test_submit_pending_jobs(dummy_template_source, tweak_settings):
             )
         ).encode("utf-8")
 
-        assert update_3_route.call_count == 1  # called to notify the job was aborted
+        assert update_3_route.call_count == 1  # called to notify the job was rejected


### PR DESCRIPTION
#### What
Add email notification to jobbergate using [SendGrid](https://docs.sendgrid.com/for-developers/sending-email/v3-python-code-example).

#### Why
We need to be able to notify Jobbergate users when their job-submissions are rejected by Slurm. This is essential given the new, asynchronous nature of remote job-submissions.

`Task`: https://app.clickup.com/t/18022949/ARMADA-536

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).
