### PR TITLE
Armada-654 improve message capture for rejected jobs in cluster agent

### DIFF
--- a/cluster_agent/jobbergate/api.py
+++ b/cluster_agent/jobbergate/api.py
@@ -67,7 +67,7 @@ async def mark_as_submitted(job_submission_id: int, slurm_job_id: int):
 
 
 @dataclass
-class NotifySubmission:
+class SubmissionNotifier:
     """
     Class used to update the status for a job submission when some error is detected.
 
@@ -78,7 +78,7 @@ class NotifySubmission:
     job_submission_id: int
     status: JobSubmissionStatus
 
-    async def update_status(self, params: DoExceptParams) -> None:
+    async def report_error(self, params: DoExceptParams) -> None:
         """
         Update the status for a job submission.
 
@@ -87,9 +87,7 @@ class NotifySubmission:
         log_error(params)
         logger.debug(f"Informing Jobbergate that the job submission was {self.status}")
         await update_status(
-            self.job_submission_id,
-            self.status,
-            reported_message=params.final_message,
+            self.job_submission_id, self.status, reported_message=params.final_message
         )
 
 

--- a/cluster_agent/jobbergate/api.py
+++ b/cluster_agent/jobbergate/api.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List
 
 from buzz import DoExceptParams
@@ -52,7 +53,7 @@ async def mark_as_submitted(job_submission_id: int, slurm_job_id: int):
     )
 
     with JobbergateApiError.handle_errors(
-        f"Could not mark job submission {job_submission_id} as updated via the API",
+        f"Could not mark job submission {job_submission_id} as submitted via the API",
         do_except=log_error,
     ):
         response = await backend_client.put(
@@ -65,19 +66,31 @@ async def mark_as_submitted(job_submission_id: int, slurm_job_id: int):
         response.raise_for_status()
 
 
-async def notify_submission_rejected(
-    params: DoExceptParams, job_submission_id: int
-) -> None:
+@dataclass
+class NotifySubmission:
     """
-    Notify Jobbergate that a job submission has been rejected.
+    Class used to update the status for a job submission when some error is detected.
+
+    It is designed to work together with py-buzz, extracting the error message,
+    logging it and sending it to Jobbergate API.
     """
-    log_error(params)
-    logger.debug("Informing Jobbergate that the job submission was rejected")
-    await update_status(
-        job_submission_id,
-        JobSubmissionStatus.REJECTED,
-        reported_message=params.final_message,
-    )
+
+    job_submission_id: int
+    status: JobSubmissionStatus
+
+    async def update_status(self, params: DoExceptParams) -> None:
+        """
+        Update the status for a job submission.
+
+        :param DoExceptParams params: Dataclass for the ``do_except`` user supplied handling method.
+        """
+        log_error(params)
+        logger.debug(f"Informing Jobbergate that the job submission was {self.status}")
+        await update_status(
+            self.job_submission_id,
+            self.status,
+            reported_message=params.final_message,
+        )
 
 
 async def update_status(

--- a/cluster_agent/jobbergate/submit.py
+++ b/cluster_agent/jobbergate/submit.py
@@ -1,18 +1,16 @@
 import json
 from typing import cast
 
-from buzz import DoExceptParams, get_traceback, reformat_exception
-
 from cluster_agent.identity.slurm_user.factory import manufacture
 from cluster_agent.identity.slurm_user.mappers import SlurmUserMapper
 from cluster_agent.identity.slurmrestd import backend_client as slurmrestd_client
 from cluster_agent.identity.slurmrestd import inject_token
 from cluster_agent.jobbergate.api import (
+    NotifySubmission,
     fetch_pending_submissions,
     mark_as_submitted,
-    notify_submission_rejected,
 )
-
+from cluster_agent.jobbergate.constants import JobSubmissionStatus
 from cluster_agent.jobbergate.schemas import (
     PendingJobSubmission,
     SlurmJobParams,
@@ -22,8 +20,9 @@ from cluster_agent.jobbergate.schemas import (
 from cluster_agent.settings import SETTINGS
 from cluster_agent.utils.exception import (
     JobSubmissionError,
-    JobbergateApiError,
+    SlurmParameterParserError,
     SlurmrestdError,
+    handle_errors_async,
 )
 from cluster_agent.utils.job_script_parser import get_job_parameters
 from cluster_agent.utils.logging import log_error
@@ -61,30 +60,50 @@ async def submit_job_script(
     :returns: The ``slurm_job_id`` for the submitted job
     """
 
-    email = pending_job_submission.job_submission_owner_email
-    name = pending_job_submission.application_name
-    mapper_class_name = user_mapper.__class__.__name__
-    logger.debug(f"Fetching username for email {email} with mapper {mapper_class_name}")
-    username = await user_mapper.find_username(email)
-    logger.debug(f"Using local slurm user {username} for job submission")
-
-    job_script = get_job_script(pending_job_submission)
-
-    submit_dir = (
-        pending_job_submission.execution_directory or SETTINGS.DEFAULT_SLURM_WORK_DIR
+    notify_submission_rejected = NotifySubmission(
+        pending_job_submission.id, JobSubmissionStatus.REJECTED
     )
 
-    local_script_path = submit_dir / f"{name}.job"
-    local_script_path.write_text(job_script)
+    async with handle_errors_async(
+        "An internal error occurred while processing the job-submission",
+        raise_exc_class=JobSubmissionError,
+        do_except=notify_submission_rejected.update_status,
+    ):
+
+        email = pending_job_submission.job_submission_owner_email
+        name = pending_job_submission.application_name
+        mapper_class_name = user_mapper.__class__.__name__
+        logger.debug(
+            f"Fetching username for email {email} with mapper {mapper_class_name}"
+        )
+        username = await user_mapper.find_username(email)
+        logger.debug(f"Using local slurm user {username} for job submission")
+
+        job_script = get_job_script(pending_job_submission)
+
+        submit_dir = (
+            pending_job_submission.execution_directory
+            or SETTINGS.DEFAULT_SLURM_WORK_DIR
+        )
+
+        local_script_path = submit_dir / f"{name}.job"
+        local_script_path.write_text(job_script)
+
     logger.debug(f"Copied job_script to local file {local_script_path}.")
 
-    job_parameters = get_job_parameters(
-        job_script,
-        name=pending_job_submission.application_name,
-        current_working_directory=submit_dir,
-        standard_output=submit_dir / f"{name}.out",
-        standard_error=submit_dir / f"{name}.err",
-    )
+    async with handle_errors_async(
+        "Failed to extract Slurm parameters",
+        raise_exc_class=SlurmParameterParserError,
+        do_except=notify_submission_rejected.update_status,
+    ):
+
+        job_parameters = get_job_parameters(
+            job_script,
+            name=pending_job_submission.application_name,
+            current_working_directory=submit_dir,
+            standard_output=submit_dir / f"{name}.out",
+            standard_error=submit_dir / f"{name}.err",
+        )
 
     payload = SlurmJobSubmission(
         script=job_script,
@@ -95,9 +114,10 @@ async def submit_job_script(
         f"to slurm with payload {payload}"
     )
 
-    with SlurmrestdError.handle_errors(
+    async with handle_errors_async(
         "Failed to submit job to slurm",
-        do_except=log_error,
+        raise_exc_class=SlurmrestdError,
+        do_except=notify_submission_rejected.update_status,
     ):
         response = await slurmrestd_client.post(
             "/slurm/v0.0.36/job/submit",
@@ -134,38 +154,20 @@ async def submit_pending_jobs():
 
     for pending_job_submission in pending_job_submissions:
         logger.debug(f"Submitting pending job_submission {pending_job_submission.id}")
-        try:
-            slurm_job_id = await submit_job_script(pending_job_submission, user_mapper)
-        except Exception as err:
-            final_message = reformat_exception(
-                (
-                    f"Failed to submit pending job_submission {pending_job_submission.id}"
-                    "...skipping to next pending job"
-                ),
-                err,
-            )
-            with JobbergateApiError.handle_errors(
-                f"Could not update status='REJECTED' for {pending_job_submission.id=} via the API",
-                do_except=log_error,
-                re_raise=False,
-            ):
-                await notify_submission_rejected(
-                    DoExceptParams(
-                        JobSubmissionError,
-                        final_message=final_message,
-                        trace=get_traceback(),
-                    ),
-                    pending_job_submission.id,
-                )
-        else:
-            with JobbergateApiError.handle_errors(
-                f"Could not update status='SUBMITTED' for {pending_job_submission.id=} via the API",
-                do_except=log_error,
-                re_raise=False,
-            ):
-                await mark_as_submitted(pending_job_submission.id, slurm_job_id)
+        with JobSubmissionError.handle_errors(
+            (
+                f"Failed to sumbit pending job_submission {pending_job_submission.id}"
+                "...skipping to next pending job"
+            ),
+            do_except=log_error,
+            do_else=lambda: logger.debug(
+                f"Finished submitting pending job_submission {pending_job_submission.id}"
+            ),
+            re_raise=False,
+        ):
 
-        logger.debug(
-            f"Finished processing pending job_submission {pending_job_submission.id}"
-        )
+            slurm_job_id = await submit_job_script(pending_job_submission, user_mapper)
+
+            await mark_as_submitted(pending_job_submission.id, slurm_job_id)
+
     logger.debug("...Finished submitting pending jobs")

--- a/cluster_agent/utils/exception.py
+++ b/cluster_agent/utils/exception.py
@@ -1,5 +1,19 @@
 """Core module for exception related operations"""
-from buzz import Buzz
+from asyncio import iscoroutinefunction
+import contextlib
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
+from buzz import Buzz, get_traceback, reformat_exception
+from buzz.tools import DoExceptParams, noop
 
 
 class ClusterAgentError(Buzz):
@@ -24,3 +38,85 @@ class JobbergateApiError(ClusterAgentError):
 
 class JobSubmissionError(ClusterAgentError):
     """Raise exception when a job cannot be submitted raises any error"""
+
+
+class SlurmParameterParserError(ClusterAgentError):
+    """Raise exception when Slurm mapper or SBATCH parser face any error"""
+
+
+@contextlib.asynccontextmanager
+async def handle_errors_async(
+    message: str,
+    raise_exc_class: Union[Type[Exception], None] = Exception,
+    raise_args: Optional[Iterable[Any]] = None,
+    raise_kwargs: Optional[Mapping[str, Any]] = None,
+    handle_exc_class: Union[Type[Exception], Tuple[Type[Exception], ...]] = Exception,
+    do_finally: Callable[[], None] = noop,
+    do_except: Callable[[DoExceptParams], None] = noop,
+    do_else: Callable[[], None] = noop,
+) -> Iterator[None]:
+    """
+    Async context manager that will intercept exceptions and repackage them with a message attached.
+
+    Example:
+
+    .. code-block:: python
+
+       with handle_errors("It didn't work"):
+           some_code_that_might_raise_an_exception()
+
+    :param: message:           The message to attach to the raised exception.
+    :param: raise_exc_class:   The exception type to raise with the constructed message
+                               if an exception is caught in the managed context.
+
+                               Defaults to Exception.
+
+                               If ``None`` is passed, no new exception will be raised and only the
+                               ``do_except``, ``do_else``, and ``do_finally``
+                               functions will be called.
+    :param: raise_args:        Additional positional args (after the constructed message) that will
+                               passed when raising an instance of the ``raise_exc_class``.
+    :param: raise_kwargs:      Keyword args that will be passed when raising an instance of the
+                               ``raise_exc_class``.
+    :param: handle_exc_class:  Limits the class of exceptions that will be intercepted
+                               Any other exception types will not be caught and re-packaged.
+                               Defaults to Exception (will handle all exceptions). May also be
+                               provided as a tuple of multiple exception types to handle.
+    :param: do_finally:        A function that should always be called at the end of the block.
+                               Should take no parameters.
+    :param: do_except:         A function that should be called only if there was an exception.
+                               Must accept one parameter that is an instance of the
+                               ``DoExceptParams`` dataclass. Note that the ``do_except``
+                               method is passed the *original exception*.
+    :param: do_else:           A function that should be called only if there were no
+                               exceptions encountered.
+    """
+    try:
+        yield
+    except handle_exc_class as err:
+        try:
+            final_message = reformat_exception(message, err)
+        except Exception as msg_err:
+            raise RuntimeError(f"Failed while formatting message: {repr(msg_err)}")
+
+        trace = get_traceback()
+
+        if iscoroutinefunction(do_except):
+            await do_except(DoExceptParams(err, final_message, trace))
+        else:
+            do_except(DoExceptParams(err, final_message, trace))
+
+        if raise_exc_class is not None:
+            args = raise_args or []
+            kwargs = raise_kwargs or {}
+            raise raise_exc_class(final_message, *args, **kwargs).with_traceback(trace)
+    else:
+        if iscoroutinefunction(do_else):
+            await do_else()
+        else:
+            do_else()
+    finally:
+        if iscoroutinefunction(do_finally):
+            await do_finally()
+        else:
+            do_finally()

--- a/tests/jobbergate/test_api.py
+++ b/tests/jobbergate/test_api.py
@@ -17,7 +17,7 @@ from cluster_agent.jobbergate.api import (
     fetch_pending_submissions,
     fetch_active_submissions,
     mark_as_submitted,
-    NotifySubmission,
+    SubmissionNotifier,
     update_status,
 )
 
@@ -350,7 +350,7 @@ async def test_notify_submission_rejected():
         trace=None,
     )
 
-    notify_submission_rejected = NotifySubmission(
+    notify_submission_rejected = SubmissionNotifier(
         job_submission_id, JobSubmissionStatus.REJECTED
     )
 
@@ -366,7 +366,7 @@ async def test_notify_submission_rejected():
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        await notify_submission_rejected.update_status(params)
+        await notify_submission_rejected.report_error(params)
 
         assert update_route.call_count == 1
         assert update_route.calls.last.request.content == json.dumps(


### PR DESCRIPTION
#### What
Improve message capture for rejected jobs in cluster-agent

#### Why
The email notification system implemented at Cluster-agent and Jobbergate should be able to catch the specific errors from Slurm API and act accordingly. It aims to differentiate the messages from Slurm API and the other errors we can get (for param parser, Slurm param mapper, remote job submissions, and others).

`Task`: https://app.clickup.com/t/18022949/ARMADA-654

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).