### PR TITLE
Small adjustments for publishing on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,15 @@
 # Table of contents
 
 - [Project setup](#project-setup)
-  - [Github secrets](#github-secrets)
   - [Dependencies](#dependencies)
 - [Setup parameters](#setup-parameters)
 - [Local usage example](#local-usage-exemple)
-- [Release](#release)
-- [Install the package](#install-the-package)
 
 ## Project Setup
-
-### Github Secrets
-
-* PYPI_URL
-* AWS_ACCESS_KEY_ID
-* AWS_SECRET_ACCESS_KEY_ID
-
-**NOTE**: AWS keys must have the `codeartifact:PublishPackageVersion` and `codeartifact:GetRepositoryEndpoint` permissions on resource identified by the `PYPI_URL`.
-
-To get the `PYPI_URL` run `aws codeartifact get-repository-endpoint --domain private --repository cluster-agent --format pypi`
 
 ### Dependencies
 
 * python3-venv
-* AWS CLI (>= 2.1.10)
-
-Configure the aws credentials running `aws configure`. To know which permissions do you must have check the [github secrets](#github-secrets) section.
 
 ## Setup parameters
 
@@ -66,25 +50,3 @@ Configure the aws credentials running `aws configure`. To know which permissions
 **Note**: this command assumes you're inside a virtual environment in which the package is installed.
 
 **NOTE**: beware you should care about having the same user name you're using to run the code in the slurmctld node. For example, if `cluster_agent` will run the `make run` command then the slurmctld node also must have a user called `cluster_agent`.
-
-## Release
-
-There is a GitHub action to publish the package to the codeartifact repository. Trigger it manually hence a GitHub release will also be created.
-
-## Install the package
-
-Before trying to install make sure your IAM user has the following permissions:
-
-* `codeartifact:GetAuthorizationToken`
-* `codeartifact:GetRepositoryEndpoint`
-* `codeartifact:ReadFromRepository`
-
-**NOTE**: if you're planning to install the package on codebuild make sure codebuild also has the `sts:GetServiceBearerToken` permission.
-
-Then, run:
-
-```bash
-CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain private --query authorizationToken --output text`
-
-pip3 install cluster-agent==<version> -i https://aws:$CODEARTIFACT_AUTH_TOKEN@private-<aws account id>.d.codeartifact.<aws region>.amazonaws.com/pypi/cluster-agent/simple/
-```

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [Project setup](#project-setup)
   - [Dependencies](#dependencies)
+- [Install the package](#install-the-package)
 - [Setup parameters](#setup-parameters)
 - [Local usage example](#local-usage-exemple)
 
@@ -12,6 +13,10 @@
 ### Dependencies
 
 * python3-venv
+
+## Install the package
+
+To install the package from Pypi simply run `pip install ovs-cluster-agent`.
 
 ## Setup parameters
 

--- a/setup.py
+++ b/setup.py
@@ -6,15 +6,16 @@ here = dirname(__file__)
 _VERSION = "1.6.0"
 
 setup(
-    name="cluster-agent",
+    name="ovs-cluster-agent",
     version=_VERSION,
     description="Cluster API data aggregator",
     long_description=open(join(here, "README.md")).read(),
+    long_description_content_type="text/markdown",
     license="MIT",
     author="omnivector-solutions",
     author_email="info@omnivector.solutions",
-    url="https://github.com/omnivector-solutions/cluster-agent/",
-    download_url="https://github.com/omnivector-solutions/cluster-agent/dist/cluster-agent-"
+    url="https://github.com/omnivector-solutions/ovs-cluster-agent/",
+    download_url="https://github.com/omnivector-solutions/ovs-cluster-agent/dist/cluster-agent-"
     + _VERSION
     + "tar.gz",
     install_requires=list(map(lambda string: string.strip("\n"), open("requirements.txt", "r"))),


### PR DESCRIPTION
This PR applies three slightly adjustments for making able the package to be published on pypi:

* Remove sections form README specifically related to CodeArtifact;
* Set `long_description_content_type` in setup.py;
* Rename published project from `cluster-agent` to `ovs-cluster-agent`.