### PR TITLE
ASP-2101 Patch --exclusive SBATCH parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ This file keeps track of all notable changes to the Cluster Agent.
 
 Unreleased
 ----------
+* Fix SBATCH parameter --exclusive
 
 2.0.0 - 2022-08-17
 ------------------

--- a/cluster_agent/utils/job_script_parser.py
+++ b/cluster_agent/utils/job_script_parser.py
@@ -92,7 +92,17 @@ sbatch_to_slurm = [
     SbatchToSlurm("distribution", "--distribution", "-m"),
     SbatchToSlurm("standard_error", "--error", "-e"),
     SbatchToSlurm("", "--exclude", "-x"),
-    SbatchToSlurm("exclusive", "--exclusive"),
+    SbatchToSlurm(
+        "exclusive",
+        "--exclusive",
+        "",
+        dict(
+            type=str,
+            choices={"user", "mcs", "exclusive", "oversubscribe"},
+            nargs="?",
+            const="exclusive",
+        ),
+    ),
     SbatchToSlurm("", "--export"),
     SbatchToSlurm("", "--export-file"),
     SbatchToSlurm("", "--extra-node-info", "-B"),

--- a/cluster_agent/utils/job_script_parser.py
+++ b/cluster_agent/utils/job_script_parser.py
@@ -149,7 +149,12 @@ sbatch_to_slurm = [
     SbatchToSlurm("open_mode", "--open-mode"),
     SbatchToSlurm("standard_output", "--output", "-o"),
     SbatchToSlurm("", "--overcommit", "-O", dict(action="store_const", const=True)),
-    SbatchToSlurm("", "--oversubscribe", "-s", dict(action="store_const", const=True)),
+    SbatchToSlurm(
+        "",
+        "--oversubscribe",
+        "-s",
+        dict(action="store_const", const="oversubscribe", dest="exclusive"),
+    ),
     SbatchToSlurm("", "--parsable", "", dict(action="store_const", const=True)),
     SbatchToSlurm("partition", "--partition", "-p"),
     SbatchToSlurm("", "--power"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -454,11 +454,15 @@ class TestBidictMapping:
 
 class TestExclusiveParameter:
     """
-    --exclusive is a special SBATCH parameter that can be used in two different ways:
+    --exclusive is a special SBATCH parameter that can be used in some different ways:
 
-    1. --exclusive as a flag, meaning the value True should be recovered for slurmd.
+    1. --exclusive as a flag, meaning the value 'exclusive' should be recovered for slurmd.
     2. --exclusive=<value>, meaning the value <value> should be recovered for slurmd.
     According to the Slurm documentation, the value can be 'user' or 'mcs'.
+    3. On top of that, 'exclusive' is expected to be set to 'oversubscribe' when the
+    flag --oversubscribe is used.
+
+    Note: When both are used, the last of them takes precedence.
     """
 
     def test_empty_jobscript(self):
@@ -508,3 +512,54 @@ class TestExclusiveParameter:
 
         with pytest.raises(ValueError, match="invalid choice: 'test-test'"):
             jobscript_to_dict(jobscript)
+
+    def test_oversubscribe(self):
+        """
+        Test the third scenario: --oversubscribe as a flag.
+        """
+        jobscript = "#SBATCH --oversubscribe"
+
+        desired_dict = {"exclusive": "oversubscribe"}
+
+        actual_dict = jobscript_to_dict(jobscript)
+
+        assert actual_dict == desired_dict
+
+    def test_oversubscribe_with_incorrect_value(self):
+        """
+        Test the second scenario with an incorrect value, ValueError should be raised.
+        """
+        jobscript = "#SBATCH --oversubscribe=test-test"
+
+        with pytest.raises(
+            ValueError, match="Unrecognized SBATCH arguments: test-test"
+        ):
+            jobscript_to_dict(jobscript)
+
+    def test_both_exclusive_and_oversubscribe_1(self):
+        """
+        Test that when both are used, the last of them takes precedence.
+
+        In this case, --exclusive is the last one.
+        """
+        jobscript = "#SBATCH --oversubscribe\n#SBATCH --exclusive"
+
+        desired_dict = {"exclusive": "exclusive"}
+
+        actual_dict = jobscript_to_dict(jobscript)
+
+        assert actual_dict == desired_dict
+
+    def test_both_exclusive_and_oversubscribe_2(self):
+        """
+        Test that when both are used, the last of them takes precedence.
+
+        In this case, --oversubscribe is the last one.
+        """
+        jobscript = "#SBATCH --exclusive\n#SBATCH --oversubscribe"
+
+        desired_dict = {"exclusive": "oversubscribe"}
+
+        actual_dict = jobscript_to_dict(jobscript)
+
+        assert actual_dict == desired_dict


### PR DESCRIPTION
#### What
Patch the `--exclusive` SBATCH parameter.

#### Why
An issue was reported and after further investigation, it was identified that `--exclusive` is a special SBATCH parameter that can be used in two different ways:

1. `--exclusive` as a flag, meaning the value `True` should be recovered for slurmd.
2. `--exclusive=<value>`, meaning the value <value> should be recovered for slurmd. According to the Slurm documentation, the value can be `user` or `mcs`.

`Task`: https://jira.scania.com/browse/ASP-2101

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).