### PR TITLE
ASP-2569 Enhancement: Capture rejection message from Slurm

### DIFF
--- a/.github/workflows/publish-action.yaml
+++ b/.github/workflows/publish-action.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8
 
       - name: Install twine
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+2.1.0-rc.1 - 2022-12-21
+-----------------------
+
 * Removed job-script parser to extract the name and values of the SBATCH parameters contained in the file.
 * Added logic to pull `execution_parameters` from job submissions and use them as job properties when jobs are submitted.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
-2.1.0-rc.1 - 2022-12-21
------------------------
+2.1.0 2023-01-03
+----------------
 
 * Removed job-script parser to extract the name and values of the SBATCH parameters contained in the file.
 * Added logic to pull `execution_parameters` from job submissions and use them as job properties when jobs are submitted.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+* Capture rejection message from Slurm
+
 2.1.0 2023-01-03
 ----------------
 

--- a/cluster_agent/jobbergate/api.py
+++ b/cluster_agent/jobbergate/api.py
@@ -95,7 +95,9 @@ async def update_status(
     """
     Update a job submission with a status
     """
-    logger.debug(f"Updating {job_submission_id=} with status={status}")
+    logger.debug(
+        f"Updating {job_submission_id=} with {status=} due to {report_message=}"
+    )
 
     with JobbergateApiError.handle_errors(
         f"Could not update status for job submission {job_submission_id} via the API",

--- a/cluster_agent/jobbergate/schemas.py
+++ b/cluster_agent/jobbergate/schemas.py
@@ -62,13 +62,17 @@ class SlurmJobSubmission(pydantic.BaseModel):
     job: SlurmJobParams
 
 
-class SlurmSubmitError(pydantic.BaseModel, extra=pydantic.Extra.ignore):
+class SlurmSubmitError(pydantic.BaseModel):
     """
     Specialized model for error content in a SlurmSubmitResponse.
     """
 
     error: Optional[str]
-    errno: Optional[int]
+    error_code: Optional[int] = pydantic.Field(alias="errno")
+
+    class Config:
+        allow_population_by_field_name = True
+        extra = pydantic.Extra.ignore
 
 
 class SlurmSubmitResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 
 here = dirname(__file__)
 
-_VERSION = "2.0.1"
+_VERSION = "2.1.0-rc.1"
 
 setup(
     name="ovs-cluster-agent",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 
 here = dirname(__file__)
 
-_VERSION = "2.1.0-rc.1"
+_VERSION = "2.1.0"
 
 setup(
     name="ovs-cluster-agent",


### PR DESCRIPTION
#### What
* Use jobbergate-agent to store the error message provided by Slurm when a job submission is rejected
* Improve the logging for this kind of error at the jobbergate-agent

#### Why
As a jobbergate user and maintainer, I would like to access the error message provided by Slurm when a job submission is rejected. To do so, jobbergate should use the database column report_message to store this information, and in this way, speed up troubleshooting.

`Task`: https://jira.scania.com/browse/ASP-2569

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).