### PR TITLE
ASP-2570 Enhancement: Capture failure message from Slurm at jobbergate-agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ----------
 
 * Capture rejection message from Slurm
+* Capture failure message from Slurm jobs
 
 2.1.0 2023-01-03
 ----------------

--- a/cluster_agent/jobbergate/api.py
+++ b/cluster_agent/jobbergate/api.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from buzz import DoExceptParams
+from loguru import logger
+
 from cluster_agent.identity.cluster_api import backend_client
 from cluster_agent.jobbergate.constants import JobSubmissionStatus
 from cluster_agent.jobbergate.schemas import ActiveJobSubmission, PendingJobSubmission
 from cluster_agent.utils.exception import JobbergateApiError
 from cluster_agent.utils.logging import log_error
-from loguru import logger
 
 
 async def fetch_pending_submissions() -> List[PendingJobSubmission]:
@@ -20,7 +21,9 @@ async def fetch_pending_submissions() -> List[PendingJobSubmission]:
     ):
         response = await backend_client.get("/jobbergate/job-submissions/agent/pending")
         response.raise_for_status()
-        pending_job_submissions = [PendingJobSubmission(**pjs) for pjs in response.json()]
+        pending_job_submissions = [
+            PendingJobSubmission(**pjs) for pjs in response.json()
+        ]
 
     logger.debug(f"Retrieved {len(pending_job_submissions)} pending job submissions")
     return pending_job_submissions
@@ -90,7 +93,10 @@ class SubmissionNotifier:
 
 
 async def update_status(
-    job_submission_id: int, status: JobSubmissionStatus, *, report_message: str = ""
+    job_submission_id: int,
+    status: JobSubmissionStatus,
+    *,
+    report_message: Optional[str] = None,
 ) -> None:
     """
     Update a job submission with a status

--- a/cluster_agent/jobbergate/finish.py
+++ b/cluster_agent/jobbergate/finish.py
@@ -1,13 +1,14 @@
 from loguru import logger
 
+from cluster_agent.identity.slurmrestd import backend_client as slurmrestd_client
 from cluster_agent.jobbergate.api import fetch_active_submissions, update_status
-from cluster_agent.jobbergate.constants import JobSubmissionStatus, status_map
+from cluster_agent.jobbergate.constants import JobSubmissionStatus
+from cluster_agent.jobbergate.schemas import SlurmSubmittedJobStatus
 from cluster_agent.utils.exception import SlurmrestdError
 from cluster_agent.utils.logging import log_error
-from cluster_agent.identity.slurmrestd import backend_client as slurmrestd_client
 
 
-async def fetch_job_status(slurm_job_id: int) -> JobSubmissionStatus:
+async def fetch_job_status(slurm_job_id: int) -> SlurmSubmittedJobStatus:
 
     logger.debug(f"Fetching slurm job status for slurm job {slurm_job_id}")
 
@@ -24,12 +25,9 @@ async def fetch_job_status(slurm_job_id: int) -> JobSubmissionStatus:
         len(jobs) == 1,
         f"Couldn't find a slurm job matching id {slurm_job_id}",
     )
-    job = jobs.pop()
-    slurm_status = job["job_state"]
-    logger.debug(f"Slurm status for slurm job {slurm_job_id} is {slurm_status}")
-    jobbergate_status = status_map[job["job_state"]]
-    logger.debug(f"Jobbergate status for slurm job {slurm_job_id} is {jobbergate_status}")
-    return jobbergate_status
+    slurm_status = SlurmSubmittedJobStatus.parse_obj(jobs.pop())
+    logger.debug(f"Status for slurm job {slurm_job_id} is {slurm_status}")
+    return slurm_status.jobbergate_status
 
 
 async def finish_active_jobs():
@@ -43,7 +41,9 @@ async def finish_active_jobs():
 
     for active_job_submission in active_job_submissions:
         skip = "skipping to next active job"
-        logger.debug(f"Fetching status of job_submission {active_job_submission.id} from slurm")
+        logger.debug(
+            f"Fetching status of job_submission {active_job_submission.id} from slurm"
+        )
 
         try:
             status = await fetch_job_status(active_job_submission.slurm_job_id)

--- a/cluster_agent/jobbergate/schemas.py
+++ b/cluster_agent/jobbergate/schemas.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional
 
 import pydantic
 
+from cluster_agent.jobbergate.constants import JobSubmissionStatus, status_map
+
 
 class JobScriptFiles(pydantic.BaseModel, extra=pydantic.Extra.ignore):
     """
@@ -83,3 +85,19 @@ class SlurmSubmitResponse(pydantic.BaseModel, extra=pydantic.Extra.ignore):
 
     errors: List[SlurmSubmitError] = []
     job_id: Optional[int]
+
+
+class SlurmSubmittedJobStatus(pydantic.BaseModel, extra=pydantic.Extra.ignore):
+    """
+    Specialized model for the cluster-agent to pull a concluded job_submission.
+    """
+
+    job_id: Optional[int]
+    job_state: Optional[str]
+    state_reason: Optional[str]
+
+    @property
+    def jobbergate_status(self) -> Optional[JobSubmissionStatus]:
+        if self.job_state:
+            return status_map[self.job_state]
+        return None

--- a/tests/jobbergate/test_api.py
+++ b/tests/jobbergate/test_api.py
@@ -314,12 +314,12 @@ async def test_update_status__success():
 
         await update_status(1, JobSubmissionStatus.COMPLETED)
         assert update_route.calls.last.request.content == json.dumps(
-            dict(new_status=JobSubmissionStatus.COMPLETED, report_message="")
+            dict(new_status=JobSubmissionStatus.COMPLETED, report_message=None)
         ).encode("utf-8")
 
         await update_status(2, JobSubmissionStatus.FAILED)
         assert update_route.calls.last.request.content == json.dumps(
-            dict(new_status=JobSubmissionStatus.FAILED, report_message="")
+            dict(new_status=JobSubmissionStatus.FAILED, report_message=None)
         ).encode("utf-8")
 
         assert update_route.call_count == 2


### PR DESCRIPTION
#### What
Use jobbergate/cluster-agent to store the error message provided by Slurm when a job submission fails at runtime. To do so, jobbergate should use the database column report_message to store this information, and in this way, speed up troubleshooting.

#### Why
As a jobbergate user and maintainer, I would like to access the error message provided by Slurm when a job submission fails at runtime.

`Task`: https://jira.scania.com/browse/ASP-2570

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).