### PR TITLE
ASP-2719 Recover the agent when a connection to LDAP server fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+* Added the ability to recover the agent when a connection to the LDAP server fails
+
 2.2.0 2023-01-25
 ----------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+2.2.0 2023-01-25
+----------------
+
 * Capture rejection message from Slurm
 * Capture failure message from Slurm jobs
 

--- a/cluster_agent/identity/slurm_user/mappers/ldap.py
+++ b/cluster_agent/identity/slurm_user/mappers/ldap.py
@@ -1,7 +1,7 @@
 import json
 
 from ldap3 import ALL, NTLM, RESTARTABLE, SIMPLE, Connection, Server
-from ldap3.utils.log import BASIC, set_library_log_detail_level
+from ldap3.utils.log import ERROR, set_library_log_detail_level
 from loguru import logger
 
 from cluster_agent.identity.slurm_user.constants import LDAPAuthType
@@ -10,7 +10,7 @@ from cluster_agent.identity.slurm_user.mappers.mapper_base import SlurmUserMappe
 from cluster_agent.settings import Settings
 from cluster_agent.utils.logging import log_error
 
-set_library_log_detail_level(BASIC)
+set_library_log_detail_level(ERROR)
 
 
 class LDAPMapper(SlurmUserMapper):

--- a/cluster_agent/identity/slurm_user/mappers/ldap.py
+++ b/cluster_agent/identity/slurm_user/mappers/ldap.py
@@ -1,6 +1,7 @@
 import json
 
-from ldap3 import ALL, NTLM, SIMPLE, Connection, Server
+from ldap3 import ALL, NTLM, RESTARTABLE, SIMPLE, Connection, Server
+from ldap3.utils.log import BASIC, set_library_log_detail_level
 from loguru import logger
 
 from cluster_agent.identity.slurm_user.constants import LDAPAuthType
@@ -8,6 +9,8 @@ from cluster_agent.identity.slurm_user.exceptions import LDAPError
 from cluster_agent.identity.slurm_user.mappers.mapper_base import SlurmUserMapper
 from cluster_agent.settings import Settings
 from cluster_agent.utils.logging import log_error
+
+set_library_log_detail_level(BASIC)
 
 
 class LDAPMapper(SlurmUserMapper):
@@ -62,9 +65,11 @@ class LDAPMapper(SlurmUserMapper):
                 user=username,
                 password=password,
                 authentication=auth_type,
+                client_strategy=RESTARTABLE,
             )
             self.connection.start_tls()
             self.connection.bind()
+        logger.debug("Connection established to LDAP")
 
     async def find_username(self, email: str) -> str:
         """

--- a/cluster_agent/main.py
+++ b/cluster_agent/main.py
@@ -60,7 +60,9 @@ async def finish_jobs():
 
 
 try:
-    sentry_logging = LoggingIntegration(level=logging.INFO, event_level=logging.ERROR)
+    sentry_logging = LoggingIntegration(
+        level=logging.WARNING, event_level=logging.ERROR
+    )
 
     sentry_sdk.init(
         dsn=SETTINGS.SENTRY_DSN,

--- a/cluster_agent/utils/logging.py
+++ b/cluster_agent/utils/logging.py
@@ -1,9 +1,10 @@
 """Core module for logging operations"""
 
+import logging
 from traceback import format_tb
 
-from loguru import logger
 from buzz import DoExceptParams
+from loguru import logger
 
 
 def log_error(params: DoExceptParams):
@@ -24,3 +25,32 @@ def log_error(params: DoExceptParams):
             ]
         )
     )
+
+
+class InterceptHandler(logging.Handler):
+    """
+    Intercept python logging messages and forward them to loguru.
+
+    Reference:
+    https://loguru.readthedocs.io/en/stable/overview.html#entirely-compatible-with-standard-logging
+    """
+
+    def emit(self, record):
+        # Get corresponding Loguru level if it exists
+        try:
+            level = logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find caller from where originated the logged message
+        frame, depth = logging.currentframe(), 2
+        while frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        logger.opt(depth=depth, exception=record.exc_info).log(
+            level, record.getMessage()
+        )
+
+
+logging.basicConfig(handlers=[InterceptHandler()], level=0)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 
 here = dirname(__file__)
 
-_VERSION = "2.1.0"
+_VERSION = "2.2.0"
 
 setup(
     name="ovs-cluster-agent",

--- a/tests/identity/slurm_user/mappers/test_ldap.py
+++ b/tests/identity/slurm_user/mappers/test_ldap.py
@@ -5,6 +5,7 @@ Define tests for the ldap mapper.
 import json
 
 import pytest
+from ldap3 import RESTARTABLE
 
 from cluster_agent.identity.slurm_user.exceptions import LDAPError
 from cluster_agent.identity.slurm_user.mappers import ldap
@@ -33,6 +34,7 @@ async def test_configure__success(mocker, tweak_settings):
             user=SETTINGS.LDAP_USERNAME,
             password=SETTINGS.LDAP_PASSWORD,
             authentication=ldap.SIMPLE,
+            client_strategy=RESTARTABLE,
         )
     assert mapper.search_base == "DC=dummy,DC=domain,DC=com"
 
@@ -60,6 +62,7 @@ async def test_configure__sets_up_ntlm_auth_type_correctly(mocker, tweak_setting
             user=f"{SETTINGS.LDAP_DOMAIN}\\{SETTINGS.LDAP_USERNAME}",
             password=SETTINGS.LDAP_PASSWORD,
             authentication=ldap.NTLM,
+            client_strategy=RESTARTABLE,
         )
     assert mapper.search_base == "DC=dummy,DC=domain,DC=com"
 
@@ -215,7 +218,9 @@ async def test_find_username__fails_if_entries_cannot_be_extracted(
             await mapper.find_username("dummy_user@dummy.domain.com")
 
 
-async def test_find_username__fails_if_user_has_more_than_one_CN(mocker, tweak_settings):
+async def test_find_username__fails_if_user_has_more_than_one_CN(
+    mocker, tweak_settings
+):
     """
     Test that the ``find_username()`` fails if a user has more than one username.
 


### PR DESCRIPTION
#### What
* Make the connection to the LDAP server restartable.
* Improve logging.

#### Why
As a Jobbergate maintainer, I need to implement a mechanism to restart the connection between jobbergate's agent and Scania's LDAP server if necessary, so the agent does not get blocked while waiting for a response.

`Task`: https://jira.scania.com/browse/ASP-2719

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).