### PR TITLE
ASP-2719 Add a timeout to the LDAP connection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
-2.2.1 2023-02-29
+* Added a timeout to the LDAP connection
+
+2.2.1 2023-02-09
 ----------------
 
 * Added the ability to recover the agent when a connection to the LDAP server fails

--- a/cluster_agent/identity/slurm_user/mappers/ldap.py
+++ b/cluster_agent/identity/slurm_user/mappers/ldap.py
@@ -13,6 +13,8 @@ from cluster_agent.utils.logging import log_error
 
 set_library_log_detail_level(ERROR)
 
+TIMEOUT_SECONDS = 30
+
 
 class LDAPMapper(SlurmUserMapper):
     """
@@ -57,7 +59,7 @@ class LDAPMapper(SlurmUserMapper):
 
         logger.debug(f"Connecting to LDAP at {host} ({domain}) with {username}")
         with LDAPError.handle_errors("Couldn't connect to LDAP", do_except=log_error):
-            with timeout(30):
+            with timeout(TIMEOUT_SECONDS):
                 logger.debug("Creating server object")
                 server = Server(host, get_info=ALL)
                 logger.debug("Creating connection object")

--- a/cluster_agent/identity/slurm_user/mappers/ldap.py
+++ b/cluster_agent/identity/slurm_user/mappers/ldap.py
@@ -13,8 +13,6 @@ from cluster_agent.utils.logging import log_error
 
 set_library_log_detail_level(ERROR)
 
-TIMEOUT_SECONDS = 30
-
 
 class LDAPMapper(SlurmUserMapper):
     """
@@ -22,6 +20,7 @@ class LDAPMapper(SlurmUserMapper):
     """
 
     connection = None
+    _timeout_seconds = 30
 
     async def configure(self, settings: Settings):
         """
@@ -59,7 +58,7 @@ class LDAPMapper(SlurmUserMapper):
 
         logger.debug(f"Connecting to LDAP at {host} ({domain}) with {username}")
         with LDAPError.handle_errors("Couldn't connect to LDAP", do_except=log_error):
-            with timeout(TIMEOUT_SECONDS):
+            with timeout(self._timeout_seconds):
                 logger.debug("Creating server object")
                 server = Server(host, get_info=ALL)
                 logger.debug("Creating connection object")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ httpx==0.23.0
 py-buzz==3.1.0
 ldap3==2.9.1
 python-jose==3.3.0
+timeoutcontext==1.2.0

--- a/tests/identity/slurm_user/mappers/test_ldap.py
+++ b/tests/identity/slurm_user/mappers/test_ldap.py
@@ -50,10 +50,7 @@ async def test_configure__raises_TimeoutError(mocker, tweak_settings):
         "cluster_agent.identity.slurm_user.mappers.ldap.Server",
         lambda *args, **kwargs: time.sleep(test_timeout),
     )
-    mocker.patch(
-        "cluster_agent.identity.slurm_user.mappers.ldap.TIMEOUT_SECONDS",
-        test_timeout / 2.0,
-    )
+    mocker.patch.object(mapper, "_timeout_seconds", test_timeout / 2.0)
 
     with tweak_settings(
         LDAP_DOMAIN="dummy.domain.com",


### PR DESCRIPTION
#### What
* Add a timeout to the LDAP connection
* Improve logging.

#### Why
As a Jobbergate maintainer, I need to implement a mechanism to restart the connection between jobbergate's agent and Scania's LDAP server if necessary, so the agent does not get blocked while waiting for a response.

`Task`: https://jira.scania.com/browse/ASP-2719

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).