### PR TITLE
ASP-3502 Set slurm restd version dynamically on cluster-agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+2.2.2 2023-02-28
+----------------
+
 * Added a timeout to the LDAP connection
 
 2.2.1 2023-02-09

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ This file keeps track of all notable changes to the Cluster Agent.
 Unreleased
 ----------
 
+* Added support to set slurm restd version dynamically
+
 2.2.2 2023-02-28
 ----------------
 

--- a/cluster_agent/agent.py
+++ b/cluster_agent/agent.py
@@ -8,8 +8,7 @@ import hostlist
 
 
 async def upsert_partitions():
-
-    r = await slurmrestd_client.get("/slurm/v0.0.36/partitions")
+    r = await slurmrestd_client.get("/partitions")
     SlurmrestdError.require_condition(
         r.status_code == 200,
         f"Slurmrestd returned {r.status_code} when calling {r.url}: {r.text}",
@@ -19,7 +18,6 @@ async def upsert_partitions():
     tasks = list()
 
     for partition in partitions["partitions"]:
-
         # transform nodes names string into a list
         # e.g. "juju-54c58e-[67,45]" -> ["juju-54c58e-67", "juju-54c58e-45"]
         partition["nodes"] = hostlist.expand_hostlist(partition["nodes"])
@@ -44,8 +42,7 @@ async def upsert_partitions():
 
 
 async def upsert_nodes():
-
-    r = await slurmrestd_client.get("/slurm/v0.0.36/nodes")
+    r = await slurmrestd_client.get("/nodes")
     SlurmrestdError.require_condition(
         r.status_code == 200,
         f"Slurmrestd returned {r.status_code} when calling {r.url}: {r.text}",
@@ -55,7 +52,6 @@ async def upsert_nodes():
     tasks = list()
 
     for node in nodes["nodes"]:
-
         payload = {
             "meta": nodes["meta"],
             "errors": nodes["errors"],
@@ -76,22 +72,22 @@ async def upsert_nodes():
 
 
 async def update_diagnostics():
-
-    r = await slurmrestd_client.get("/slurm/v0.0.36/diag/")
+    r = await slurmrestd_client.get("/diag/")
     SlurmrestdError.require_condition(
         r.status_code == 200,
         f"Slurmrestd returned {r.status_code} when calling {r.url}: {r.text}",
     )
     diagnostics = r.json()
 
-    response = await cluster_api_client.post("/cluster/agent/diagnostics", json=diagnostics)
+    response = await cluster_api_client.post(
+        "/cluster/agent/diagnostics", json=diagnostics
+    )
 
     return response.status_code
 
 
 async def upsert_jobs():
-
-    r = await slurmrestd_client.get("/slurm/v0.0.36/jobs")
+    r = await slurmrestd_client.get("/jobs")
     SlurmrestdError.require_condition(
         r.status_code == 200,
         f"Slurmrestd returned {r.status_code} when calling {r.url}: {r.text}",
@@ -101,7 +97,6 @@ async def upsert_jobs():
     tasks = list()
 
     for job in jobs["jobs"]:
-
         payload = {
             "meta": jobs["meta"],
             "errors": jobs["errors"],

--- a/cluster_agent/identity/slurmrestd.py
+++ b/cluster_agent/identity/slurmrestd.py
@@ -145,8 +145,12 @@ class AsyncBackendClient(httpx.AsyncClient):
     _token: typing.Optional[str]
 
     def __init__(self):
+        if SETTINGS.SLURM_RESTD_VERSIONED_URL is None:
+            raise ValueError(
+                "SLURM_RESTD_VERSIONED_URL must be set in order to use the AsyncBackendClient"
+            )
         super().__init__(
-            base_url=SETTINGS.BASE_SLURMRESTD_URL,
+            base_url=SETTINGS.SLURM_RESTD_VERSIONED_URL,
             auth=inject_token,
             event_hooks=dict(
                 request=[self._log_request],

--- a/cluster_agent/jobbergate/finish.py
+++ b/cluster_agent/jobbergate/finish.py
@@ -9,14 +9,13 @@ from cluster_agent.utils.logging import log_error
 
 
 async def fetch_job_status(slurm_job_id: int) -> SlurmSubmittedJobStatus:
-
     logger.debug(f"Fetching slurm job status for slurm job {slurm_job_id}")
 
     with SlurmrestdError.handle_errors(
         "Failed to fetch job status from slurm",
         do_except=log_error,
     ):
-        response = await slurmrestd_client.get(f"/slurm/v0.0.36/job/{slurm_job_id}")
+        response = await slurmrestd_client.get(f"/job/{slurm_job_id}")
         response.raise_for_status()
         data = response.json()
 

--- a/cluster_agent/jobbergate/submit.py
+++ b/cluster_agent/jobbergate/submit.py
@@ -86,7 +86,6 @@ async def submit_job_script(
         raise_exc_class=JobSubmissionError,
         do_except=notify_submission_rejected.report_error,
     ):
-
         email = pending_job_submission.job_submission_owner_email
         name = pending_job_submission.application_name
         mapper_class_name = user_mapper.__class__.__name__
@@ -114,7 +113,6 @@ async def submit_job_script(
         raise_exc_class=SlurmParameterParserError,
         do_except=notify_submission_rejected.report_error,
     ):
-
         job_parameters = get_job_parameters(
             pending_job_submission.execution_parameters,
             name=pending_job_submission.application_name,
@@ -135,11 +133,11 @@ async def submit_job_script(
         do_except=notify_submission_rejected.report_error,
     ):
         response = await slurmrestd_client.post(
-            "/slurm/v0.0.36/job/submit",
+            "/job/submit",
             auth=lambda r: inject_token(r, username=username),
             json=json.loads(payload.json()),
         )
-        logger.debug(f"Slurmrestd response: {response.json()}")
+        logger.debug(f"Slurmrestd response: {response.text}")
         sub_data = SlurmSubmitResponse.parse_raw(response.content)
         with handle_errors(unpack_error_from_slurm_response(sub_data)):
             response.raise_for_status()
@@ -181,7 +179,6 @@ async def submit_pending_jobs():
             ),
             re_raise=False,
         ):
-
             slurm_job_id = await submit_job_script(pending_job_submission, user_mapper)
 
             await mark_as_submitted(pending_job_submission.id, slurm_job_id)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import dirname, join
 
 here = dirname(__file__)
 
-_VERSION = "2.2.0"
+_VERSION = "2.2.2"
 
 setup(
     name="ovs-cluster-agent",
@@ -18,21 +18,24 @@ setup(
     download_url="https://github.com/omnivector-solutions/ovs-cluster-agent/dist/cluster-agent-"
     + _VERSION
     + "tar.gz",
-    install_requires=list(map(lambda string: string.strip("\n"), open("requirements.txt", "r"))),
-    extras_require=dict(dev=[
-        "pytest==7.1.0",
-        "pytest-mock==3.7.0",
-        "respx==0.19.2",
-        "asynctest==0.13.0",
-        "pytest-asyncio==0.18.2",
-        "black==22.3.0",
-        "flake8==4.0.1",
-        "pytest-env==0.6.2",
-        "pytest-random-order==1.0.4",
-        "pytest-cov==3.0.0",
-        "freezegun==1.2.2",
-
-    ]),
+    install_requires=list(
+        map(lambda string: string.strip("\n"), open("requirements.txt", "r"))
+    ),
+    extras_require=dict(
+        dev=[
+            "pytest==7.1.0",
+            "pytest-mock==3.7.0",
+            "respx==0.19.2",
+            "asynctest==0.13.0",
+            "pytest-asyncio==0.18.2",
+            "black==22.3.0",
+            "flake8==4.0.1",
+            "pytest-env==0.6.2",
+            "pytest-random-order==1.0.4",
+            "pytest-cov==3.0.0",
+            "freezegun==1.2.2",
+        ]
+    ),
     packages=find_packages(),
     keywords=["armada", "hpc"],
     classifiers=[

--- a/tests/jobbergate/test_finish.py
+++ b/tests/jobbergate/test_finish.py
@@ -37,7 +37,7 @@ async def test_fetch_pending_submissions__success(
                 status_code=200, json=dict(access_token="dummy-token")
             )
         )
-        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/{slurm_id}").mock(
+        respx.get(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/{slurm_id}").mock(
             return_value=httpx.Response(
                 status_code=200,
                 json=dict(
@@ -74,7 +74,7 @@ async def test_fetch_pending_submissions__raises_SlurmrestdError_if_response_is_
                 status_code=200, json=dict(access_token="dummy-token")
             )
         )
-        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/11").mock(
+        respx.get(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/11").mock(
             return_value=httpx.Response(status_code=400)
         )
         with pytest.raises(
@@ -136,7 +136,9 @@ async def test_finish_active_jobs():
                 ),
             )
 
-        slurm_route = respx.get(url__regex=rf"{SETTINGS.BASE_SLURMRESTD_URL}/job/\d+")
+        slurm_route = respx.get(
+            url__regex=rf"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/\d+"
+        )
         slurm_route.mock(side_effect=_map_slurm_request)
 
         def _map_update_request(request: httpx.Request):

--- a/tests/jobbergate/test_finish.py
+++ b/tests/jobbergate/test_finish.py
@@ -37,7 +37,7 @@ async def test_fetch_pending_submissions__success(
                 status_code=200, json=dict(access_token="dummy-token")
             )
         )
-        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/{slurm_id}").mock(
+        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/{slurm_id}").mock(
             return_value=httpx.Response(
                 status_code=200,
                 json=dict(
@@ -74,7 +74,7 @@ async def test_fetch_pending_submissions__raises_SlurmrestdError_if_response_is_
                 status_code=200, json=dict(access_token="dummy-token")
             )
         )
-        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/11").mock(
+        respx.get(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/11").mock(
             return_value=httpx.Response(status_code=400)
         )
         with pytest.raises(
@@ -136,9 +136,7 @@ async def test_finish_active_jobs():
                 ),
             )
 
-        slurm_route = respx.get(
-            url__regex=rf"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/\d+"
-        )
+        slurm_route = respx.get(url__regex=rf"{SETTINGS.BASE_SLURMRESTD_URL}/job/\d+")
         slurm_route.mock(side_effect=_map_slurm_request)
 
         def _map_update_request(request: httpx.Request):

--- a/tests/jobbergate/test_submit.py
+++ b/tests/jobbergate/test_submit.py
@@ -85,7 +85,7 @@ async def test_submit_job_script__success(
     name = pending_job_submission.application_name
 
     async with respx.mock:
-        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
+        submit_route = respx.post(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -152,7 +152,7 @@ async def test_submit_job_script__with_non_default_execution_directory(
     )
 
     async with respx.mock:
-        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
+        submit_route = respx.post(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -235,7 +235,7 @@ async def test_submit_job_script__raises_exception_if_submit_call_response_is_no
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
+        submit_route = respx.post(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=400,
@@ -286,7 +286,7 @@ async def test_submit_job_script__raises_exception_if_response_cannot_be_unpacke
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
+        submit_route = respx.post(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -384,7 +384,7 @@ async def test_submit_pending_jobs(dummy_job_script_files, tweak_settings):
                     json=dict(job_id=fake_slurm_job_id),
                 )
 
-        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
+        submit_route = respx.post(f"{SETTINGS.SLURM_RESTD_VERSIONED_URL}/job/submit")
         submit_route.mock(side_effect=_submit_side_effect)
 
         with tweak_settings(SINGLE_USER_SUBMITTER="dummy-user"):

--- a/tests/jobbergate/test_submit.py
+++ b/tests/jobbergate/test_submit.py
@@ -85,9 +85,7 @@ async def test_submit_job_script__success(
     name = pending_job_submission.application_name
 
     async with respx.mock:
-        submit_route = respx.post(
-            f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/submit"
-        )
+        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -154,9 +152,7 @@ async def test_submit_job_script__with_non_default_execution_directory(
     )
 
     async with respx.mock:
-        submit_route = respx.post(
-            f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/submit"
-        )
+        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -239,9 +235,7 @@ async def test_submit_job_script__raises_exception_if_submit_call_response_is_no
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        submit_route = respx.post(
-            f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/submit"
-        )
+        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=400,
@@ -292,9 +286,7 @@ async def test_submit_job_script__raises_exception_if_response_cannot_be_unpacke
         )
         update_route.mock(return_value=httpx.Response(status_code=200))
 
-        submit_route = respx.post(
-            f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/submit"
-        )
+        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
         submit_route.mock(
             return_value=httpx.Response(
                 status_code=200,
@@ -392,9 +384,7 @@ async def test_submit_pending_jobs(dummy_job_script_files, tweak_settings):
                     json=dict(job_id=fake_slurm_job_id),
                 )
 
-        submit_route = respx.post(
-            f"{SETTINGS.BASE_SLURMRESTD_URL}/slurm/v0.0.36/job/submit"
-        )
+        submit_route = respx.post(f"{SETTINGS.BASE_SLURMRESTD_URL}/job/submit")
         submit_route.mock(side_effect=_submit_side_effect)
 
         with tweak_settings(SINGLE_USER_SUBMITTER="dummy-user"):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -53,7 +53,7 @@ async def test_upsert_partitions(
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/partitions"
+        SETTINGS.BASE_SLURMRESTD_URL + "/partitions"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -79,7 +79,7 @@ async def test_upsert_partitions(
             ),
         )
     ]
-    mock_slurmrestd_client.get.assert_awaited_with("/slurm/v0.0.36/partitions")
+    mock_slurmrestd_client.get.assert_awaited_with("/partitions")
     mock_asyncio.gather.assert_awaited_once()
     assert test_response == [200]
 
@@ -97,7 +97,7 @@ async def test_upsert_partitions__raise_error_in_case_slurmrestd_returns_4xx_or_
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/partitions"
+    url = SETTINGS.BASE_SLURMRESTD_URL + "/partitions"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -147,7 +147,7 @@ async def test_upsert_nodes(
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/nodes"
+        SETTINGS.BASE_SLURMRESTD_URL + "/nodes"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -171,7 +171,7 @@ async def test_upsert_nodes(
             ),
         )
     ]
-    mock_slurmrestd_client.get.assert_awaited_with("/slurm/v0.0.36/nodes")
+    mock_slurmrestd_client.get.assert_awaited_with("/nodes")
     mock_asyncio.gather.assert_awaited_once()
     assert test_response == [200]
 
@@ -189,7 +189,7 @@ async def test_upsert_nodes__raise_error_in_case_slurmrestd_returns_4xx_or_5xx(
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/nodes"
+    url = SETTINGS.BASE_SLURMRESTD_URL + "/nodes"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -235,7 +235,7 @@ async def test_update_diagnostics(
     )
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/diag/"
+        SETTINGS.BASE_SLURMRESTD_URL + "/diag/"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -247,7 +247,7 @@ async def test_update_diagnostics(
     mock_cluster_api_client.post.assert_awaited_once_with(
         "/cluster/agent/diagnostics", json=mock_diagnostics_response_body
     )
-    mock_slurmrestd_client.get.assert_awaited_once_with("/slurm/v0.0.36/diag/")
+    mock_slurmrestd_client.get.assert_awaited_once_with("/diag/")
 
     assert test_response == 200
 
@@ -265,7 +265,7 @@ async def test_update_diagnostics__raise_error_in_case_slurmrestd_returns_4xx_or
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/diag/"
+    url = SETTINGS.BASE_SLURMRESTD_URL + "/diag/"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -311,9 +311,7 @@ async def test_upsert_jobs(
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
-    mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/jobs"
-    )
+    mock_slurmrestd_client.get.return_value.url = SETTINGS.BASE_SLURMRESTD_URL + "/jobs"
     mock_slurmrestd_client.get.return_value.text = "no error"
 
     mock_response_status = mock.Mock()
@@ -336,7 +334,7 @@ async def test_upsert_jobs(
             ),
         )
     ]
-    mock_slurmrestd_client.get.assert_awaited_with("/slurm/v0.0.36/jobs")
+    mock_slurmrestd_client.get.assert_awaited_with("/jobs")
     mock_asyncio.gather.assert_awaited_once()
     assert test_response == [200]
 
@@ -354,7 +352,7 @@ async def test_upsert_jobs__raise_error_in_case_slurmrestd_returns_4xx_or_5xx(
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/slurm/v0.0.36/jobs"
+    url = SETTINGS.BASE_SLURMRESTD_URL + "/jobs"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -53,7 +53,7 @@ async def test_upsert_partitions(
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/partitions"
+        SETTINGS.SLURM_RESTD_VERSIONED_URL + "/partitions"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -97,7 +97,7 @@ async def test_upsert_partitions__raise_error_in_case_slurmrestd_returns_4xx_or_
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/partitions"
+    url = SETTINGS.SLURM_RESTD_VERSIONED_URL + "/partitions"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -147,7 +147,7 @@ async def test_upsert_nodes(
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/nodes"
+        SETTINGS.SLURM_RESTD_VERSIONED_URL + "/nodes"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -189,7 +189,7 @@ async def test_upsert_nodes__raise_error_in_case_slurmrestd_returns_4xx_or_5xx(
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/nodes"
+    url = SETTINGS.SLURM_RESTD_VERSIONED_URL + "/nodes"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -235,7 +235,7 @@ async def test_update_diagnostics(
     )
     mock_slurmrestd_client.get.return_value.status_code = 200
     mock_slurmrestd_client.get.return_value.url = (
-        SETTINGS.BASE_SLURMRESTD_URL + "/diag/"
+        SETTINGS.SLURM_RESTD_VERSIONED_URL + "/diag/"
     )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
@@ -265,7 +265,7 @@ async def test_update_diagnostics__raise_error_in_case_slurmrestd_returns_4xx_or
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/diag/"
+    url = SETTINGS.SLURM_RESTD_VERSIONED_URL + "/diag/"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code
@@ -311,7 +311,9 @@ async def test_upsert_jobs(
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.json.return_value = mock_response_body
     mock_slurmrestd_client.get.return_value.status_code = 200
-    mock_slurmrestd_client.get.return_value.url = SETTINGS.BASE_SLURMRESTD_URL + "/jobs"
+    mock_slurmrestd_client.get.return_value.url = (
+        SETTINGS.SLURM_RESTD_VERSIONED_URL + "/jobs"
+    )
     mock_slurmrestd_client.get.return_value.text = "no error"
 
     mock_response_status = mock.Mock()
@@ -352,7 +354,7 @@ async def test_upsert_jobs__raise_error_in_case_slurmrestd_returns_4xx_or_5xx(
     """
 
     error_message = "dummy error message"
-    url = SETTINGS.BASE_SLURMRESTD_URL + "/jobs"
+    url = SETTINGS.SLURM_RESTD_VERSIONED_URL + "/jobs"
 
     mock_slurmrestd_client.get = asynctest.CoroutineMock()
     mock_slurmrestd_client.get.return_value.status_code = response_status_code

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,12 +8,12 @@ class TestSettingsSlurmrestdUrl:
         """
         url = "http://localhost:6820"
         settings = Settings(BASE_SLURMRESTD_URL=url)
-        assert settings.BASE_SLURMRESTD_URL == f"{url}/slurm/v0.0.36"
+        assert settings.SLURM_RESTD_VERSIONED_URL == f"{url}/slurm/v0.0.36"
 
     def test_default_version_is_not_added_if_already_present(self):
         """
         Test that the default version is not added to the url if it is already present.
         """
         url = "http://localhost:6820/slurm/v0.0.39"
-        settings = Settings(BASE_SLURMRESTD_URL=url)
-        assert settings.BASE_SLURMRESTD_URL == url
+        settings = Settings(SLURM_RESTD_VERSIONED_URL=url)
+        assert settings.SLURM_RESTD_VERSIONED_URL == url

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,19 @@
+from cluster_agent.settings import Settings
+
+
+class TestSettingsSlurmrestdUrl:
+    def test_default_version_is_added_for_backward_compatibility(self):
+        """
+        Test that the default version is added to the url if it is not present.
+        """
+        url = "http://localhost:6820"
+        settings = Settings(BASE_SLURMRESTD_URL=url)
+        assert settings.BASE_SLURMRESTD_URL == f"{url}/slurm/v0.0.36"
+
+    def test_default_version_is_not_added_if_already_present(self):
+        """
+        Test that the default version is not added to the url if it is already present.
+        """
+        url = "http://localhost:6820/slurm/v0.0.39"
+        settings = Settings(BASE_SLURMRESTD_URL=url)
+        assert settings.BASE_SLURMRESTD_URL == url


### PR DESCRIPTION
#### What
Set slurm restd version dynamically on cluster-agent.

#### Why
As a Jobbergate maintainer, I need more control over the slurm restd version used on requests, so that it can be set dynamically from the infra bundles and work with different slurm versions.

`Task`: https://jira.scania.com/browse/ASP-3502

---

#### Peer Review
Please follow the upstream omnivector documentation concerning
[peer-review guidelines](https://github.com/omnivector-solutions/Documentation/blob/main/Contributing/pr_review_standards.md#peer-review).